### PR TITLE
Add multiple result sets.

### DIFF
--- a/DbMocker.Tests/DbMockTableTests.cs
+++ b/DbMocker.Tests/DbMockTableTests.cs
@@ -75,6 +75,35 @@ namespace DbMocker.Tests
         }
 
         [TestMethod]
+        public void Mock_ReturnsMultiple_MockTable_Test()
+        {
+            var conn = new MockDbConnection();
+
+            MockTable table1 = MockTable.WithColumns("Col1", "Col2")
+                                 .AddRow(11, 12);
+            MockTable table2 = MockTable.WithColumns("Col3", "Col4")
+                     .AddRow("aa", 3.4);
+
+            conn.Mocks
+                .WhenAny()
+                .ReturnsDataset(table1, table2);
+
+            DbCommand cmd = conn.CreateCommand();
+            DbDataReader result = cmd.ExecuteReader();
+
+            Assert.IsTrue(result.Read());
+
+            Assert.AreEqual(11, result.GetInt32(0));
+            Assert.AreEqual(12, result.GetInt32(1));
+
+            Assert.IsTrue(result.NextResult());
+            Assert.IsTrue(result.Read());
+
+            Assert.AreEqual("aa", result.GetString(0));
+            Assert.AreEqual(3.4, result.GetDouble(1));
+        }
+
+        [TestMethod]
         public void Mock_ReturnsSimple_MockRow_Test()
         {
             var conn = new MockDbConnection();

--- a/DbMocker/Data/MockDbCommand.cs
+++ b/DbMocker/Data/MockDbCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 
 namespace Apps72.Dev.Data.DbMocker.Data
 {
@@ -33,7 +34,8 @@ namespace Apps72.Dev.Data.DbMocker.Data
         public override object ExecuteScalar()
         {
             return _connection.Mocks
-                              .GetFirstMockTableFound(new MockCommand(this))
+                              .GetFirstMockTablesFound(new MockCommand(this))
+                              .First()
                               .GetFirstColRowOrNull();
         }
 
@@ -41,7 +43,7 @@ namespace Apps72.Dev.Data.DbMocker.Data
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
             var result = _connection.Mocks
-                                    .GetFirstMockTableFound(new MockCommand(this));
+                                    .GetFirstMockTablesFound(new MockCommand(this));
 
             return new MockDbDataReader(result);
         }

--- a/DbMocker/Data/MockDbDataReader.cs
+++ b/DbMocker/Data/MockDbDataReader.cs
@@ -6,14 +6,16 @@ namespace Apps72.Dev.Data.DbMocker.Data
 {
     public class MockDbDataReader : DbDataReader
     {
+        private MockTable[] tables;
+        private int _currentTableIndex = -1;
         private MockColumn[] _columns;
         private object[,] _rows;
         private int _currentRowIndex = -1;
 
-        internal MockDbDataReader(MockTable table)
+        internal MockDbDataReader(MockTable[] tables)
         {
-            _columns = table.Columns ?? Array.Empty<MockColumn>();
-            _rows = table.Rows ?? new object[,] { };
+            this.tables = tables;
+            NextResult();
         }
 
         #region LEGACY METHODS
@@ -161,7 +163,16 @@ namespace Apps72.Dev.Data.DbMocker.Data
 
         public override bool NextResult()
         {
-            return false;       // TODO when using datasets
+            _currentTableIndex++;
+
+            if (_currentTableIndex >= tables.Length)
+                return false;
+
+            _columns = tables[_currentTableIndex].Columns ?? Array.Empty<MockColumn>();
+            _rows = tables[_currentTableIndex].Rows ?? new object[,] { };
+            _currentRowIndex = -1;
+
+            return true;
         }
 
         public override bool Read()

--- a/DbMocker/MockConditions.cs
+++ b/DbMocker/MockConditions.cs
@@ -75,7 +75,7 @@ namespace Apps72.Dev.Data.DbMocker
         }
 
         /// <summary />
-        internal MockTable GetFirstMockTableFound(MockCommand command)
+        internal MockTable[] GetFirstMockTablesFound(MockCommand command)
         {
             foreach (MockReturns item in Conditions)
             {

--- a/DbMocker/MockReturns.cs
+++ b/DbMocker/MockReturns.cs
@@ -13,10 +13,30 @@ namespace Apps72.Dev.Data.DbMocker
         internal string Description { get; set; }
 
         /// <summary />
-        internal Func<MockCommand, MockTable> ReturnsFunction { get; set; }
+        internal Func<MockCommand, MockTable[]> ReturnsFunction { get; set; }
 
         /// <summary />
         internal Func<MockCommand, bool> Condition { get; set; }
+
+        /// <summary>
+        /// Sets the expression to return a multiple result set, presented by an array of
+        /// <seealso cref="MockTable"/> with sample data, when the condition occured.
+        /// </summary>
+        /// <param name="returns">Method or Lambda expression to return a <seealso cref="MockTable"/></param>
+        public void ReturnsDataset(params MockTable[] returns)
+        {
+            ReturnsFunction = (cmd) => returns;
+        }
+
+        /// <summary>
+        /// Sets the expression to return a multiple result set, presented by an array of
+        /// <seealso cref="MockTable"/> with sample data, when the condition occured.
+        /// </summary>
+        /// <param name="returns">Method or Lambda expression to return a <seealso cref="MockTable"/></param>
+        public void ReturnsDataset(Func<MockCommand, MockTable[]> returns)
+        {
+            ReturnsFunction = returns;
+        }
 
         /// <summary>
         /// Sets the expression to return a <seealso cref="MockTable"/> with sample data, when the condition occured.
@@ -24,7 +44,7 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns">Method or Lambda expression to return a <seealso cref="MockTable"/></param>
         public void ReturnsTable(Func<MockCommand, MockTable> returns)
         {
-            ReturnsFunction = returns;
+            ReturnsFunction = (cmd) => new[] { returns.Invoke(cmd) };
         }
 
         /// <summary>
@@ -33,7 +53,7 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns"><seealso cref="MockTable"/> with sample data</param>
         public void ReturnsTable(MockTable returns)
         {
-            ReturnsFunction = (cmd) => returns;
+            ReturnsFunction = (cmd) => new[] { returns };
         }
 
         /// <summary>
@@ -44,7 +64,7 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns">Sample data</param>
         public void ReturnsRow<T>(Func<MockCommand, T> returns)
         {
-            ReturnsFunction = (cmd) => ConvertToMockTable(returns.Invoke(cmd));
+            ReturnsFunction = (cmd) => ConvertToMockTables(returns.Invoke(cmd));
         }
 
         /// <summary>
@@ -55,7 +75,7 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns">Sample data</param>
         public void ReturnsRow<T>(T returns)
         {
-            ReturnsFunction = (cmd) => ConvertToMockTable(returns);
+            ReturnsFunction = (cmd) => ConvertToMockTables(returns);
         }
 
         /// <summary>
@@ -64,7 +84,7 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns"><seealso cref="MockTable"/> with sample data</param>
         public void ReturnsRow(MockTable returns)
         {
-            ReturnsFunction = (cmd) => returns;
+            ReturnsFunction = (cmd) => new[] { returns };
         }
 
         /// <summary>
@@ -75,11 +95,11 @@ namespace Apps72.Dev.Data.DbMocker
         {
             if (returns == null)
             {
-                ReturnsFunction = (cmd) => ConvertToMockTable(returns);
+                ReturnsFunction = (cmd) => ConvertToMockTables(returns);
             }
             else
             {
-                ReturnsFunction = (cmd) => ConvertToMockTable(returns.Invoke(cmd));
+                ReturnsFunction = (cmd) => ConvertToMockTables(returns.Invoke(cmd));
             }
         }
 
@@ -89,7 +109,13 @@ namespace Apps72.Dev.Data.DbMocker
         /// <param name="returns">Value to return</param>
         public void ReturnsScalar<T>(T returns)
         {
-            ReturnsFunction = (cmd) => ConvertToMockTable(returns);
+            ReturnsFunction = (cmd) => ConvertToMockTables(returns);
+        }
+
+        /// <summary />
+        private MockTable[] ConvertToMockTables<T>(T returns)
+        {
+            return new[] { ConvertToMockTable(returns) };
         }
 
         /// <summary />


### PR DESCRIPTION
Sometimes one has to mock stored procedures with multiple result sets. Mocking multiple tables going to look like below (see also unit tests):
```C#
MockTable table1 = MockTable.WithColumns("Col1", "Col2")
                     .AddRow(11, 12);
conn.Mocks
    .WhenAny()
    .ReturnsTable(table1);

MockTable table2 = MockTable.WithColumns("Col3", "Col4")
         .AddRow("aa", 3.4);
conn.Mocks
    .WhenAny()
    .ReturnsTable(table2);
```