### PR TITLE
Consistent NewLine detection

### DIFF
--- a/DbMocker/Constants.cs
+++ b/DbMocker/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Apps72.Dev.Data.DbMocker
+{
+    public class Constants
+    {
+        internal static readonly char[] SPLIT_NEWLINE = { '\r', '\n' };
+    }
+}

--- a/DbMocker/MockConditions.cs
+++ b/DbMocker/MockConditions.cs
@@ -9,7 +9,6 @@ namespace Apps72.Dev.Data.DbMocker
     public class MockConditions
     {
         internal bool MustValidateSqlServerCommandText = false;
-        private static readonly string NEW_LINE = Environment.NewLine;
         private List<MockReturns> _conditions = new List<MockReturns>();
 
         /// <summary />
@@ -44,9 +43,12 @@ namespace Apps72.Dev.Data.DbMocker
                 description: $"WhenTag({tagName})",
                 condition: (cmd) =>
                 {
-                    string toSearch = $"-- {tagName}{NEW_LINE}";
-                    return cmd.CommandText.StartsWith(toSearch) ||
-                           cmd.CommandText.Contains($"{NEW_LINE}{toSearch}");
+                    string toSearch = $"-- {tagName}";
+
+                    var lines = cmd.CommandText
+                        .Split(Constants.SPLIT_NEWLINE, StringSplitOptions.RemoveEmptyEntries);
+
+                    return lines.Contains(toSearch);
                 });
         }
 

--- a/DbMocker/MockTableImport.cs
+++ b/DbMocker/MockTableImport.cs
@@ -8,8 +8,6 @@ namespace Apps72.Dev.Data.DbMocker
 {
     public partial class MockTable
     {
-        private static readonly string[] SPLIT_NEWLINE = new string[] { Environment.NewLine };
-
         /// <summary />
         public static MockTable FromCsv(string content, string delimiter, CsvImportOptions options)
         {
@@ -20,7 +18,7 @@ namespace Apps72.Dev.Data.DbMocker
             bool mustRemoveEmptyLines = (options & CsvImportOptions.RemoveEmptyLines) == CsvImportOptions.RemoveEmptyLines;
             bool mustTrimLines = (options & CsvImportOptions.TrimLines) == CsvImportOptions.TrimLines;
 
-            foreach (string row in content.Split(SPLIT_NEWLINE, StringSplitOptions.None))
+            foreach (string row in content.Split(Constants.SPLIT_NEWLINE, StringSplitOptions.None))
             {
                 if (mustRemoveEmptyLines && string.IsNullOrEmpty(row))
                 {


### PR DESCRIPTION
6 tests failed for me with git config settings for line endings that leave as-is. Some of the in-line strings contain line-endings that then aren't compatible with the detection.