### PR TITLE
Delete Microsoft.SqlServer.SqlParser.dll and direct reference on it f…

### DIFF
--- a/DbMocker/DbMocker.csproj
+++ b/DbMocker/DbMocker.csproj
@@ -32,7 +32,7 @@ conn.Mocks
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.20216.14" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.21099.39" />
   </ItemGroup>
 
 </Project>

--- a/DbMocker/DbMocker.csproj
+++ b/DbMocker/DbMocker.csproj
@@ -32,14 +32,6 @@ conn.Mocks
   </PropertyGroup>
 
   <ItemGroup>
-	<None Include="..\Library\Microsoft.SqlServer.SqlParser.dll">
-        <PackagePath>lib\netstandard2.0</PackagePath>
-        <Pack>true</Pack>
-        <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.20216.14" />
   </ItemGroup>
 


### PR DESCRIPTION
…rom DbMocker.csproj

(according to the git history was added due to only beta version of the  nuget package was available)