### PR TITLE
#27 Fix the ExecuteScalar method to return the defined value

### DIFF
--- a/DbMocker.Tests/DatabaseCommandTests.cs
+++ b/DbMocker.Tests/DatabaseCommandTests.cs
@@ -48,6 +48,51 @@ namespace DbMocker.Tests
         }
 
         [TestMethod]
+        public void Mock_ContainsSql_NullableIntegerScalar_Null_Test()
+        {
+            // Issue #27 - https://github.com/Apps72/DbMocker/issues/27
+            // https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.executescalar
+            //   If the first column of the first row in the result set is not found, a null reference is returned.
+
+            var conn = new MockDbConnection();
+
+            conn.Mocks
+                .When(c => c.CommandText.Contains("SELECT"))
+                .ReturnsScalar((int?)null);
+
+            using (var cmd = new DatabaseCommand(conn))
+            {
+                cmd.CommandText.AppendLine("SELECT ...");
+
+                var result = cmd.ExecuteScalar();
+
+                Assert.AreEqual(null, result);
+            }
+        }
+
+        [TestMethod]
+        public void Mock_ContainsSql_NullableIntegerScalar_DbNull_Test()
+        {
+            // Issue #27 - https://github.com/Apps72/DbMocker/issues/27
+            // https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.executescalar
+            //   If the value in the database is null, the query returns DBNull.Value.
+
+            var conn = new MockDbConnection();
+
+            conn.Mocks
+                .When(c => c.CommandText.Contains("SELECT"))
+                .ReturnsScalar(DBNull.Value);
+
+            using (var cmd = new DatabaseCommand(conn))
+            {
+                cmd.CommandText.AppendLine("SELECT ...");
+                var result = cmd.ExecuteScalar();
+
+                Assert.AreEqual(DBNull.Value, result);
+            }
+        }
+
+        [TestMethod]
         public void Mock_ContainsSql_IntegerScalar_DbNull_Test()
         {
             var conn = new MockDbConnection();

--- a/DbMocker.Tests/DbMockTableTests.cs
+++ b/DbMocker.Tests/DbMockTableTests.cs
@@ -172,7 +172,7 @@ namespace DbMocker.Tests
 
             conn.Mocks
                 .WhenAny()
-                .ReturnsScalar<object>(null);
+                .ReturnsScalar<object>(DBNull.Value);
 
             object result = conn.CreateCommand().ExecuteScalar();
 

--- a/DbMocker/MockReturns.cs
+++ b/DbMocker/MockReturns.cs
@@ -199,7 +199,7 @@ namespace Apps72.Dev.Data.DbMocker
                     Columns = Columns.WithNames(string.Empty),
                     Rows = new object[,]
                     {
-                        { GetValueOrDbNull(returns) }
+                        { returns }
                     }
                 };
             }


### PR DESCRIPTION
#27 Fix the ExecuteScalar method to return the defined value (null or DBNull) and not to convert DBNull to null.