### PR TITLE
1.24.0 - implementation of GetBytes method

### DIFF
--- a/DbMocker.Tests/DbMockTableTests.cs
+++ b/DbMocker.Tests/DbMockTableTests.cs
@@ -214,6 +214,24 @@ namespace DbMocker.Tests
         }
 
         [TestMethod]
+        public void Mock_ReturnsRow_ByteArray_Test()
+        {
+            var conn = new MockDbConnection();
+            conn.Mocks
+                .WhenAny()
+                .ReturnsRow(new { Hash = new byte[] { 0, 1, 2, 4, 0, 0 } });
+
+            var reader = conn.CreateCommand().ExecuteReader();
+            reader.Read();
+            var buffer = new byte[] { 0, 0, 0, 0, 0, 0 };
+            var readBytesCount = reader.GetBytes(0, 1, buffer, 2, 3);
+
+            Assert.AreEqual(buffer[2], 1);
+            Assert.AreEqual(buffer[3], 2);
+            Assert.AreEqual(buffer[4], 4);
+        }
+
+        [TestMethod]
         public void Mock_ReturnsScalar_MockTableSingle_Test()
         {
             var conn = new MockDbConnection();

--- a/DbMocker/Data/MockDbDataReader.cs
+++ b/DbMocker/Data/MockDbDataReader.cs
@@ -49,6 +49,8 @@ namespace Apps72.Dev.Data.DbMocker.Data
 
         public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
         {
+            var byteArray = (byte[])GetValue(ordinal);
+            Array.Copy(byteArray, dataOffset, buffer, bufferOffset, length);
             return length;
         }
 

--- a/DbMocker/DbMocker.csproj
+++ b/DbMocker/DbMocker.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Apps72.Dev.Data.DbMocker</AssemblyName>
     <RootNamespace>Apps72.Dev.Data.DbMocker</RootNamespace>
-    <Version>1.23.0</Version>
+    <Version>1.24.0</Version>
     <PackageId>DbMocker</PackageId>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Denis Voituron</Authors>
@@ -25,10 +25,10 @@ conn.Mocks
     <PackageTags>DbMocker, Mocker, SQLServer, Oracle, Sqlite, EntityFramework, EF, Dapper, UnitTest</PackageTags>
     <PackageReleaseNotes>https://github.com/Apps72/DbMocker</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.23.0.0</AssemblyVersion>
+    <AssemblyVersion>1.24.0.0</AssemblyVersion>
     <PackageProjectUrl>https://github.com/Apps72/DbMocker</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Apps72/DbMocker</RepositoryUrl>
-    <FileVersion>1.23.0.0</FileVersion>
+    <FileVersion>1.24.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -253,7 +253,7 @@ var conn = new MockDbConnection()
 
 ## Version 1.24
 - #35 `MockDbDataReader.GetBytes` does fill the `buffer` param.
-  Thanks [Stepami](httpshttps://github.com/Stepami).
+  Thanks [Stepami](https://github.com/Stepami).
 
 ## Version 1.23
 - Dependencies updated.
@@ -262,7 +262,7 @@ var conn = new MockDbConnection()
 
 ## Version 1.22
 - #31 Implement the `DbDataReader.GetSchemaTable()` method.
-  Thanks [javnov](httpshttps://github.com/javnov).
+  Thanks [javnov](https://github.com/javnov).
 
 ## Version 1.21
 - #29 Fix `Dispose` method to change the ConnectionState to Closed.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -251,7 +251,7 @@ var conn = new MockDbConnection()
 
 ## Releases
 
-## Version 1.23
+## Version 1.24
 - Dependencies updated.
 - #32 Update `MockDbDataReader.IsClosed`
   Thanks [kiainlogicdk](https://github.com/kiainlogicdk) for the discussion.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -252,6 +252,10 @@ var conn = new MockDbConnection()
 ## Releases
 
 ## Version 1.24
+- #35 `MockDbDataReader.GetBytes` does fill the `buffer` param.
+  Thanks [Stepami](httpshttps://github.com/Stepami).
+
+## Version 1.23
 - Dependencies updated.
 - #32 Update `MockDbDataReader.IsClosed`
   Thanks [kiainlogicdk](https://github.com/kiainlogicdk) for the discussion.


### PR DESCRIPTION
The other day i was working on a tool that performs hashing of the data with the DB engine.
It does so by executing a SQL script, i.e. for PostgreSQL:
```
select sha512(...) from my_schema.my_table
```

Then it reads these hashes and combine them on C# code level.
I stuck with unit testing so far, as i was unable to mock `byte[]` returning from `MockDbConnection` since my service uses `GetBytes` method for data obtaining due to perfomance requirements.

That is why, I modified the method of `MockDbDataReader`, so it does fill the `buffer`